### PR TITLE
Align bookstore Q1/Q2 with overview doc examples

### DIFF
--- a/bookstore/src/main/java/BookstorePathExp.java
+++ b/bookstore/src/main/java/BookstorePathExp.java
@@ -95,7 +95,7 @@ public class BookstorePathExp {
             CTX.mapKey(Value.get("store")),
             CTX.mapKey(Value.get("book")),
             CTX.allChildren(),
-            CTX.mapKeysIn("author"));
+            CTX.mapKey(Value.get("author")));
 
         Record record = client.operate(null, key, op);
         return record.getValue("bookstore");
@@ -107,10 +107,8 @@ public class BookstorePathExp {
      * JSONPath: $.store.book[?(@.isbn)]
      */
     static Object runQ2(IAerospikeClient client, Key key) {
-        Exp hasIsbn = Exp.gt(
-            MapExp.getByKey(MapReturnType.COUNT, Exp.Type.INT,
-                Exp.val("isbn"), Exp.mapLoopVar(LoopVarPart.VALUE)),
-            Exp.val(0));
+        Exp hasIsbn = MapExp.getByKey(MapReturnType.EXISTS, Exp.Type.BOOL,
+            Exp.val("isbn"), Exp.mapLoopVar(LoopVarPart.VALUE));
 
         Operation op = CdtOperation.selectByPath("bookstore", SelectFlags.VALUE,
             CTX.mapKey(Value.get("store")),


### PR DESCRIPTION
Q1 now uses CTX.mapKey("author") for a single-key lookup instead of CTX.mapKeysIn, matching the overview page snippet. Q2 uses MapReturnType.EXISTS with a BOOL result instead of COUNT > 0, which is clearer and matches the documented "has isbn" check.
